### PR TITLE
Fix unchecked empty input

### DIFF
--- a/controllers/SecurityEventsController.php
+++ b/controllers/SecurityEventsController.php
@@ -209,7 +209,7 @@ class SecurityEventsController extends Controller
         $userId = Yii::$app->user->getId();
         $model = new SecurityEventsPage();
 
-        if($model->load(Yii::$app->request->post()) && $model->validate())
+        if($model->load(Yii::$app->request->post()) && $model->refresh_time && $model->validate())
         {
             $securityEventsPage = SecurityEventsPage::findOne(['user_id' => $userId]);
             $securityEventsPage->refresh_time = $model->refresh_time;

--- a/views/security-events/index.php
+++ b/views/security-events/index.php
@@ -366,7 +366,6 @@ foreach($chartData as $key => $record)
 
     var intervalId;
     var refreshString = "<?php echo $securityEventsPage->refresh_time; ?>";
-    //startInterval(getRefreshTime(refreshString)*1000);
 
     // Start refresh interval
     function startInterval(interval) {


### PR DESCRIPTION
Text input for refresh time in security events page was not checked properly