### PR TITLE
remove this pg_escape_string function it causes deprecated warning

### DIFF
--- a/models/Event/Analyzed.php
+++ b/models/Event/Analyzed.php
@@ -133,7 +133,7 @@ class Analyzed extends \yii\db\ActiveRecord
             for ($i = 0; $i< $max;$i++){
                 $analyzedSecurityEventsList = new AnalyzedSecurityEventsList;
                 $analyzedSecurityEventsList->events_analyzed_iteration = $fieldVal2;
-                $analyzedSecurityEventsList->analyzed_security_events_id = pg_escape_string($securityEvents[$i]["id"]);
+                $analyzedSecurityEventsList->analyzed_security_events_id = $securityEvents[$i]["id"];
                 $analyzedSecurityEventsList->security_events_id = $id;
                 $analyzedSecurityEventsList->save(true);
             }


### PR DESCRIPTION
Neni treba to escapovat lebo sa pouziva activeRecord $analyzedSecurityEventsList->save(true); urobi data sanitation

<img width="1883" height="803" alt="image" src="https://github.com/user-attachments/assets/df772b2f-bd25-44ff-b72e-73cc5e74c851" />
